### PR TITLE
Enhance damage insights and filter minor outliers in act_ws.html

### DIFF
--- a/act_ws.html
+++ b/act_ws.html
@@ -239,7 +239,7 @@
                             </el-table-column>
                             <el-table-column :label="$t('ui.damage_avg')">
                                 <template #default="scope">
-                                    <span v-if="scope.row.hit > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}}</span>
+                                    <span v-if="scope.row.hit > 0">{{numberWithComma(Math.floor(scope.row.damage / scope.row.hit))}} ({{(scope.row.damage / scope.row.hit /scope.row.max*100).toFixed(1)}}%)</span>
                                 </template>
                             </el-table-column>
                         </el-table>
@@ -863,6 +863,7 @@
                     const [source_type, source_idx, source_id, source_party_idx, ..._] = source;
                     const [target_type, target_idx, target_id, target_party_idx, ...__] = target;
                     if (target_id === 0x22a350f) return; // HARDCODE: 对欧根附加炸弹造成的伤害不进行记录
+                    if (damage < 1000) return; // HARDCODE: filter outliner damage (<1000)
                     // TODO: 自伤类技能的过滤
                     const current_record = get_latest_record();
                     current_record.last_record_at = time_ms;


### PR DESCRIPTION
- Updated act_ws.html to display the average damage as a percentage of the maximum damage (assumed to equal the damage cap), offering deeper insights into achieving the potential damage cap.
- Added a hard-coded filter in act_ws.html to ignore damage records less than 1000 (a magic number), focusing on reasonable damage instances and filtering out minor outliers to calculate a more accurate average.

- 更新了 act_ws.html，使其顯示平均傷害作為相對於最大傷害（假設等同於傷害上限）的百分比，提供對於實現潛在傷害上限的更深入見解。
- 增加了一個硬編碼過濾器來忽略小於1000的傷害記錄（一個魔法數字），專注於合理的傷害實例並過濾掉輕微的異常值，以計算更準確的平均值。

這是關於傷害上限的初步嘗試，我認為效果相當好，具體能幫助我決策替換追擊收益。我最初是將0傷害過濾，發現包含水晶等仍有許多微小傷害，只好先使用魔法數字。功能性方面，追擊、奧義明顯錯誤，且OVERDRIVE沒考慮。拋磚引玉，如果有方向我再優化。

![效果1](https://github.com/joe50261/GBFR-ACT/assets/8299577/9545b84f-bc87-4fdf-ac19-b6427789a0d5)
![效果2](https://github.com/joe50261/GBFR-ACT/assets/8299577/e12208a1-9a58-47f1-8403-d1f4ed9b7e05)
![基準](https://github.com/joe50261/GBFR-ACT/assets/8299577/19331e8c-006f-485d-a073-d34dd8c239fc)
